### PR TITLE
Allow skipping scope check for specific entityIds

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Additionally, it is also capable to handle 'scope attributes' such as _schacHome
 ## Notes and limitations
 * Regular expressions in `shibmd:Scope` are not supported.
 * It is recommended to run this filter after _oid2name_. Please note that attribute names in the module configuration are case sensitive and must match the names in attributemaps.
+* 'scope Attributes' must be singled valued, otherwise they are removed.
 
 ## Installing the module
 You can install the module with composer:
@@ -36,3 +37,9 @@ _config/config.php_
             // 'scopeAttributes' => array('schacHomeOrganization'),
        ),
 ```
+
+## Configurations Options
+
+* `attributesWithScope` an array of attributes that should be scoped and should match the scope from the metadata
+* `scopeAttributes` an array of attributes that should exactly match the scope from the metadata
+* `ignoreCheckForEntities` an array of IdP entity IDs to skip scope checking for. Useful when an IdP is a SAML proxy and is trusted to assert any scope.

--- a/lib/Auth/Process/FilterAttributes.php
+++ b/lib/Auth/Process/FilterAttributes.php
@@ -25,6 +25,8 @@ class sspmod_attributescope_Auth_Process_FilterAttributes extends SimpleSAML_Aut
         'schacHomeOrganization',
         );
 
+    private $ignoreCheckForEntities = array();
+
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
@@ -33,6 +35,9 @@ class sspmod_attributescope_Auth_Process_FilterAttributes extends SimpleSAML_Aut
         }
         if (array_key_exists('scopeAttributes', $config)) {
             $this->scopeAttributes = $config['scopeAttributes'];
+        }
+        if (array_key_exists('ignoreCheckForEntities', $config)) {
+            $this->ignoreCheckForEntities = $config['ignoreCheckForEntities'];
         }
     }
 
@@ -44,6 +49,12 @@ class sspmod_attributescope_Auth_Process_FilterAttributes extends SimpleSAML_Aut
     public function process(&$request)
     {
         $src = $request['Source'];
+
+        if (isset($src['entityid']) && in_array($src['entityid'], $this->ignoreCheckForEntities, true)) {
+            SimpleSAML_Logger::debug('Ignoring scope checking for assertions from ' . $src['entityid']);
+            return;
+        }
+
         $noscope = false;
         if (!isset($src['scope']) ||
                 !is_array($src['scope']) ||


### PR DESCRIPTION
We have a use case for skipping a scope check for specific entityIds that are SAML proxies for a large number of IdPs. I think this could be generally useful for the main module. Thanks.