### PR TITLE
Add check for attributes suffixed scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,9 @@ _config/config.php_
 ## Configurations Options
 
 * `attributesWithScope` an array of attributes that should be scoped and should match the scope from the metadata
+* `attributesWithScopeSuffix` an array of attributes that have the scope as a suffix. For example, `user@department.example.com` 
+and `department.example.com` are both suffixed with `example.com`. Useful when an SP is reliant on `mail` attribute to identify users and
+the IdP users various subdomains for mail.
 * `scopeAttributes` an array of attributes that should exactly match the scope from the metadata
 * `ignoreCheckForEntities` an array of IdP entity IDs to skip scope checking for. Useful when an IdP is a SAML proxy and is trusted to assert any scope.
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Additionally, it is also capable to handle 'scope attributes' such as _schacHome
 * Regular expressions in `shibmd:Scope` are not supported.
 * It is recommended to run this filter after _oid2name_. Please note that attribute names in the module configuration are case sensitive and must match the names in attributemaps.
 * 'scope Attributes' must be singled valued, otherwise they are removed.
+* Specifying an attribute in multiple configuration options is likely a user configuration issue. A value will only
+  pass if it conforms to the validation rule for each configured option.
 
 ## Installing the module
 You can install the module with composer:

--- a/lib/Auth/Process/FilterAttributes.php
+++ b/lib/Auth/Process/FilterAttributes.php
@@ -27,6 +27,8 @@ class sspmod_attributescope_Auth_Process_FilterAttributes extends SimpleSAML_Aut
 
     private $ignoreCheckForEntities = array();
 
+    private $attributesWithScopeSuffix = array();
+
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
@@ -38,6 +40,9 @@ class sspmod_attributescope_Auth_Process_FilterAttributes extends SimpleSAML_Aut
         }
         if (array_key_exists('ignoreCheckForEntities', $config)) {
             $this->ignoreCheckForEntities = $config['ignoreCheckForEntities'];
+        }
+        if (array_key_exists('attributesWithScopeSuffix', $config)) {
+            $this->attributesWithScopeSuffix = $config['attributesWithScopeSuffix'];
         }
     }
 
@@ -101,20 +106,65 @@ class sspmod_attributescope_Auth_Process_FilterAttributes extends SimpleSAML_Aut
                 }
             }
         }
+
+        foreach ($this->attributesWithScopeSuffix as $attributeWithSuffix) {
+            if (!isset($request['Attributes'][$attributeWithSuffix])) {
+                continue;
+            }
+            if ($noscope) {
+                SimpleSAML_Logger::info('Attribute '.$attributeWithSuffix.' is filtered out due to missing scope information in IdP metadata.');
+                unset($request['Attributes'][$attributeWithSuffix]);
+                continue;
+            }
+            $values = $request['Attributes'][$attributeWithSuffix];
+            $newValues = array();
+            foreach ($values as $value) {
+                if ($this->isProperlySuffixed($value, $scopes)) {
+                    $newValues[] = $value;
+                } else {
+                    SimpleSAML_Logger::warning('Attribute value ('.$value.') is removed by attributeWithScopeSuffix check.');
+                }
+            }
+
+            if (count($newValues)) {
+                $request['Attributes'][$attributeWithSuffix] = $newValues;
+            } else {
+                unset($request['Attributes'][$attributeWithSuffix]);
+            }
+        }
     }
 
     /**
      * Determines whether an attribute value is properly scoped.
      *
-     * @param string $value
-     * @param array  $scopes
+     * @param string $value The attribute value to check
+     * @param array  $scopes The array of scopes for the Idp
      *
-     * @return bool
+     * @return bool true if properly scoped
      */
     private function isProperlyScoped($value, $scopes)
     {
         foreach ($scopes as $scope) {
             $preg = '/^[^@]*@'.preg_quote($scope).'$/';
+            if (preg_match($preg, $value) == 1) {
+                return true;
+            }
+        }
+    }
+
+    /**
+     * Determines whether an attribute value is properly suffixed with the scope.
+     * @ and (literal) . are used for suffix boundries
+     *
+     * @param string $value The attribute value to check
+     * @param array  $scopes The array of scopes for the IdP
+     *
+     * @return bool true if attribute is suffixed with a scope
+     */
+    private function isProperlySuffixed($value, $scopes)
+    {
+        foreach ($scopes as $scope) {
+            $preg = '/^(.*[@|.])?'.preg_quote($scope).'$/';
             if (preg_match($preg, $value) == 1) {
                 return true;
             }

--- a/lib/Auth/Process/FilterAttributes.php
+++ b/lib/Auth/Process/FilterAttributes.php
@@ -145,7 +145,7 @@ class sspmod_attributescope_Auth_Process_FilterAttributes extends SimpleSAML_Aut
     private function isProperlyScoped($value, $scopes)
     {
         foreach ($scopes as $scope) {
-            $preg = '/^[^@]*@'.preg_quote($scope).'$/';
+            $preg = '/^[^@]+@'.preg_quote($scope).'$/';
             if (preg_match($preg, $value) == 1) {
                 return true;
             }
@@ -164,7 +164,7 @@ class sspmod_attributescope_Auth_Process_FilterAttributes extends SimpleSAML_Aut
     private function isProperlySuffixed($value, $scopes)
     {
         foreach ($scopes as $scope) {
-            $scopeRegex = '/^[^@]*@(.*\.)?'.preg_quote($scope).'$/';
+            $scopeRegex = '/^[^@]+@(.*\.)?'.preg_quote($scope).'$/';
             $subdomainRegex = '/^([^@]*\.)?'.preg_quote($scope).'$/';
             if (preg_match($subdomainRegex, $value) === 1 || preg_match($scopeRegex, $value) === 1) {
                 return true;

--- a/lib/Auth/Process/FilterAttributes.php
+++ b/lib/Auth/Process/FilterAttributes.php
@@ -164,8 +164,9 @@ class sspmod_attributescope_Auth_Process_FilterAttributes extends SimpleSAML_Aut
     private function isProperlySuffixed($value, $scopes)
     {
         foreach ($scopes as $scope) {
-            $preg = '/^(.*[@|.])?'.preg_quote($scope).'$/';
-            if (preg_match($preg, $value) == 1) {
+            $scopeRegex = '/^[^@]*@(.*\.)?'.preg_quote($scope).'$/';
+            $subdomainRegex = '/^([^@]*\.)?'.preg_quote($scope).'$/';
+            if (preg_match($subdomainRegex, $value) === 1 || preg_match($scopeRegex, $value) === 1) {
                 return true;
             }
         }

--- a/tests/lib/Auth/Process/FilterAttributesTest.php
+++ b/tests/lib/Auth/Process/FilterAttributesTest.php
@@ -75,7 +75,7 @@ class Test_sspmod_attributescope_Auth_Process_FilterAttributes extends PHPUnit_F
         $expectedData = array(
             'eduPersonPrincipalName' => array('joe@example.com'),
             'nonScopedAttribute' => array('not-removed'),
-            'eduPersonScopedAffiliation' => array('student@example.com', 'staff@example.com', '@example.com'),
+            'eduPersonScopedAffiliation' => array('student@example.com', 'staff@example.com'),
             'schacHomeOrganization' => array('example.com')
         );
         $config = array();
@@ -115,7 +115,8 @@ class Test_sspmod_attributescope_Auth_Process_FilterAttributes extends PHPUnit_F
                     'faculty@abc.com',
                     'student@example.com',
                     'staff@other.com',
-                    'member@a@example.com'
+                    'member@a@example.com',
+                    '@example.com'
                 ),
                 // schacHomeOrganization is required to be single valued and gets filtered out if multi-valued
                 'schacHomeOrganization' => array('abc.com', 'example.com', 'other.com')
@@ -188,19 +189,20 @@ class Test_sspmod_attributescope_Auth_Process_FilterAttributes extends PHPUnit_F
                     // Invalid values
                     'invalid-example.com', // not subdomain
                     'cexample.com',
-                    'examplecom'
+                    'examplecom',
                 ),
                 'email' => array(
                     // Valid values
                     'user@example.com',
                     'user@gsb.example.com',
-                    '@example.com',
-                    '@other.example.com',
                     // Invalid values
                     'user@invalid-example.com',
                     'user@examplecom',
                     'user@cexample.com',
-                    'abc@efg@example.com' // double '@;
+                    'abc@efg@example.com', // double '@'
+                    // scoped values need data before the '@'
+                    '@example.com',
+                    '@other.example.com',
                     ),
             ),
             'Source' => array(
@@ -224,9 +226,6 @@ class Test_sspmod_attributescope_Auth_Process_FilterAttributes extends PHPUnit_F
             'email' => array(
                 'user@example.com',
                 'user@gsb.example.com',
-                '@example.com',
-                '@other.example.com',
-
             ),
         );
         $this->assertEquals($expectedData, $attributes, "Incorrectly suffixed variables should be removed");

--- a/tests/lib/Auth/Process/FilterAttributesTest.php
+++ b/tests/lib/Auth/Process/FilterAttributesTest.php
@@ -75,7 +75,7 @@ class Test_sspmod_attributescope_Auth_Process_FilterAttributes extends PHPUnit_F
         $expectedData = array(
             'eduPersonPrincipalName' => array('joe@example.com'),
             'nonScopedAttribute' => array('not-removed'),
-            'eduPersonScopedAffiliation' => array('student@example.com', 'staff@example.com'),
+            'eduPersonScopedAffiliation' => array('student@example.com', 'staff@example.com', '@example.com'),
             'schacHomeOrganization' => array('example.com')
         );
         $config = array();
@@ -111,7 +111,12 @@ class Test_sspmod_attributescope_Auth_Process_FilterAttributes extends PHPUnit_F
         $request = array(
             'Attributes' => array(
                 'nonScopedAttribute' => array('not-removed'),
-                'eduPersonScopedAffiliation' => array('faculty@abc.com', 'student@example.com', 'staff@other.com'),
+                'eduPersonScopedAffiliation' => array(
+                    'faculty@abc.com',
+                    'student@example.com',
+                    'staff@other.com',
+                    'member@a@example.com'
+                ),
                 // schacHomeOrganization is required to be single valued and gets filtered out if multi-valued
                 'schacHomeOrganization' => array('abc.com', 'example.com', 'other.com')
             ),
@@ -176,17 +181,26 @@ class Test_sspmod_attributescope_Auth_Process_FilterAttributes extends PHPUnit_F
         $request = array(
             'Attributes' => array(
                 'department' => array(
+                    // Valid values
                     'engineering.example.com', // Subdomain
                     'example.com', // scope
-                    'invalid-example.com', // invalid: not subdomain
-                    'sexample.com', // invalid
-                    'examplecom' // invalid
+                    '.example.com',
+                    // Invalid values
+                    'invalid-example.com', // not subdomain
+                    'cexample.com',
+                    'examplecom'
                 ),
                 'email' => array(
+                    // Valid values
                     'user@example.com',
                     'user@gsb.example.com',
-                    'user@invalid-example.com', //invalid
-                    'user@examplecom' //invalid
+                    '@example.com',
+                    '@other.example.com',
+                    // Invalid values
+                    'user@invalid-example.com',
+                    'user@examplecom',
+                    'user@cexample.com',
+                    'abc@efg@example.com' // double '@;
                     ),
             ),
             'Source' => array(
@@ -205,10 +219,14 @@ class Test_sspmod_attributescope_Auth_Process_FilterAttributes extends PHPUnit_F
             'department' => array(
                 'engineering.example.com',
                 'example.com',
+                '.example.com',
             ),
             'email' => array(
                 'user@example.com',
                 'user@gsb.example.com',
+                '@example.com',
+                '@other.example.com',
+
             ),
         );
         $this->assertEquals($expectedData, $attributes, "Incorrectly suffixed variables should be removed");


### PR DESCRIPTION
We have a use case for checking attributes against a subdomain form of the scope.
Example if the scope is 'example.com' then we want to accept (for a mail attribute) `user@example.com`, `user@department.example.com`, etc.
This might be generally useful so I'm creating a PR.
If you think the use case is too specific to us (and don't want the PR) that is fine too :)